### PR TITLE
Tweak storage root initialization

### DIFF
--- a/src/main/java/one/microstream/demo/bookstore/BookStoreDemo.java
+++ b/src/main/java/one/microstream/demo/bookstore/BookStoreDemo.java
@@ -70,11 +70,12 @@ public final class BookStoreDemo
 	
 	
 	private final static ClusterStorageManager<Data> storageManager = createStorageManager();
-	private static Data                              root           = new Data();
+	private static Data                              root;
 	
 	private static ClusterStorageManager<Data> createStorageManager()
 	{
-		final ClusterStorageManager<Data> storageManager = new ClusterStorageManager<>(root);
+		final ClusterStorageManager<Data> storageManager = new ClusterStorageManager<>(new Data());
+		root = storageManager.getRoot().get();
 
 		if(root.books().bookCount() == 0)
 		{


### PR DESCRIPTION
The storage root is wrapped around Lazy<> inside the ClusterStorageManager. Due to this we need to get the root after initializing the ClusterStorageManager. If we don't do this the initialization will fail and the cluster will not be able to start.